### PR TITLE
build: Add tmp directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ out/
 
 ### VS Code ###
 .vscode/
+/tmp/


### PR DESCRIPTION
Added /tmp/ directory to .gitignore to prevent unnecessary files from
being staged.