### PR TITLE
feat(dao): Tweak account dao implementation

### DIFF
--- a/src/main/kotlin/gay/extremist/dao/AccountDao.kt
+++ b/src/main/kotlin/gay/extremist/dao/AccountDao.kt
@@ -9,6 +9,6 @@ interface AccountDao {
     suspend fun readAccountAll(): List<Account>
     suspend fun updateAccount(id: Int, username: String, email: String, password: String): Boolean
     suspend fun deleteAccount(id: Int): Boolean
-    suspend fun getToken(email: String, password: String): String
-    suspend fun getIdByUsername(username: String): Int
+    suspend fun getToken(email: String, password: String): String?
+    suspend fun getIdByUsername(username: String): Int?
 }

--- a/src/main/kotlin/gay/extremist/dao/AccountDaoImpl.kt
+++ b/src/main/kotlin/gay/extremist/dao/AccountDaoImpl.kt
@@ -26,38 +26,39 @@ class AccountDaoImpl : AccountDao {
     }
 
     override suspend fun updateAccount(id: Int, username: String, email: String, password: String): Boolean = dbQuery {
-        val account = Account.findById(id)
-        account?.username = username
-        account?.email = email
-        account?.password = password
-
-        account != null
+        return@dbQuery when (val account = Account.findById(id)) {
+            null -> false
+            else -> {
+                account.username = username
+                account.email = email
+                account.password = password
+                true
+            }
+        }
     }
 
     override suspend fun deleteAccount(id: Int): Boolean = dbQuery {
-        val account = Account.findById(id)
-        try {
-            account!!.delete()
-            true
-        } catch (e: NullPointerException) {
-            false
+        return@dbQuery when (val account = Account.findById(id)) {
+            null -> false
+            else -> {
+                account.delete()
+                true
+            }
         }
     }
 
-    override suspend fun getToken(email: String, password: String): String = dbQuery {
+    override suspend fun getToken(email: String, password: String): String? = dbQuery {
         Account.find {
             Accounts.email eq email
             Accounts.password eq password
-        }
-            .first()
-            .token
+        }.firstOrNull()?.token
     }
 
-    override suspend fun getIdByUsername(username: String): Int = dbQuery {
+    override suspend fun getIdByUsername(username: String): Int? = dbQuery {
         Account.find { Accounts.username eq username }
-            .first()
-            .id
-            .value
+            .firstOrNull()
+            ?.id
+            ?.value
     }
 
 }

--- a/src/main/kotlin/gay/extremist/dao/VideoDao.kt
+++ b/src/main/kotlin/gay/extremist/dao/VideoDao.kt
@@ -12,7 +12,7 @@ interface VideoDao {
         title: String,
         description: String,
         tags: SizedCollection<Tag>
-    ): Video?
+    ): Video
     suspend fun readVideo(id: Int): Video?
     suspend fun readVideoAll(): List<Video>
     suspend fun updateVideo(id: Int, title: String, description: String): Boolean


### PR DESCRIPTION
Implements the following changes in the AccountDao interface and its
implementation:
- Simplify the updateAccount method to use a when expression
- Simplify the deleteAccount method to use a when expression
- Modify the getToken and getIdByUsername methods to return nullable values, as the data may not be found in the database