### PR TITLE
refactor: Update references with onDelete option to CASCADE

### DIFF
--- a/src/main/kotlin/gay/extremist/dao/VideoDaoImpl.kt
+++ b/src/main/kotlin/gay/extremist/dao/VideoDaoImpl.kt
@@ -19,6 +19,7 @@ class VideoDaoImpl : VideoDao {
             this.title = title
             this.description = description
             this.tags = tags
+            this.viewCount = 0
         }
     }
 

--- a/src/main/kotlin/gay/extremist/models/AccountFollowsAccount.kt
+++ b/src/main/kotlin/gay/extremist/models/AccountFollowsAccount.kt
@@ -2,12 +2,13 @@ package gay.extremist.models
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
 
 object AccountFollowsAccount: Table() {
-    val follower: Column<EntityID<Int>> = reference("followerID", Accounts)
-    val account: Column<EntityID<Int>> = reference("accountID", Accounts)
+    val follower: Column<EntityID<Int>> = reference("followerID", Accounts, onDelete = ReferenceOption.CASCADE)
+    val account: Column<EntityID<Int>> = reference("accountID", Accounts, onDelete = ReferenceOption.CASCADE)
     override val primaryKey = PrimaryKey(
-        follower, account, name="PK_AccountFollowsAccount_fol_acc"
+        follower, account
     )
 }

--- a/src/main/kotlin/gay/extremist/models/AccountFollowsTag.kt
+++ b/src/main/kotlin/gay/extremist/models/AccountFollowsTag.kt
@@ -2,12 +2,13 @@ package gay.extremist.models
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
 
 object AccountFollowsTag: Table() {
-    private val follower: Column<EntityID<Int>> = reference("followerID", Accounts)
-    private val tag: Column<EntityID<Int>> = reference("tagID", Tags)
+    private val follower: Column<EntityID<Int>> = reference("followerID", Accounts, onDelete = ReferenceOption.CASCADE)
+    private val tag: Column<EntityID<Int>> = reference("tagID", Tags, onDelete = ReferenceOption.CASCADE)
     override val primaryKey = PrimaryKey(
-        follower, tag, name="PK_AccountFollowsTag_fol_tag"
+        follower, tag
     )
 }

--- a/src/main/kotlin/gay/extremist/models/Comment.kt
+++ b/src/main/kotlin/gay/extremist/models/Comment.kt
@@ -5,11 +5,12 @@ import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
 
 object Comments: IntIdTable() {
-    val accountID: Column<EntityID<Int>>  = reference("accountID", Accounts)
-    val videoID: Column<EntityID<Int>>  = reference("videoID", Videos)
-    val parentID: Column<EntityID<Int>?>  = reference("parentID", Comments).nullable()
+    val accountID: Column<EntityID<Int>>  = reference("accountID", Accounts, onDelete = ReferenceOption.CASCADE)
+    val videoID: Column<EntityID<Int>>  = reference("videoID", Videos, onDelete = ReferenceOption.CASCADE)
+    val parentID: Column<EntityID<Int>?>  = reference("parentID", Comments, onDelete = ReferenceOption.CASCADE).nullable()
     val comment: Column<String> = text("comment")
 }
 

--- a/src/main/kotlin/gay/extremist/models/Playlist.kt
+++ b/src/main/kotlin/gay/extremist/models/Playlist.kt
@@ -5,9 +5,10 @@ import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
 
 object Playlists: IntIdTable() {
-    val ownerId: Column<EntityID<Int>> = reference("ownerID", Accounts)
+    val ownerId: Column<EntityID<Int>> = reference("ownerID", Accounts, onDelete = ReferenceOption.CASCADE)
     val name: Column<String> = varchar("name", 255)
     val description: Column<String> = varchar("description", 255)
 }

--- a/src/main/kotlin/gay/extremist/models/PlaylistContainsVideo.kt
+++ b/src/main/kotlin/gay/extremist/models/PlaylistContainsVideo.kt
@@ -1,11 +1,12 @@
 package gay.extremist.models
 
+import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
 
 object PlaylistContainsVideo: Table() {
-    private val playlist = reference("playlistID", Tags)
-    private val video = reference("videoID", Videos)
+    private val playlist = reference("playlistID", Tags, onDelete = ReferenceOption.CASCADE)
+    private val video = reference("videoID", Videos,  onDelete = ReferenceOption.CASCADE)
     override val primaryKey = PrimaryKey(
-        playlist, video, name="PK_PlaylistContainsVideo_pl_vid"
+        playlist, video
     )
 }

--- a/src/main/kotlin/gay/extremist/models/Rating.kt
+++ b/src/main/kotlin/gay/extremist/models/Rating.kt
@@ -5,10 +5,11 @@ import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
 
 object Ratings: IntIdTable() {
-    val videoID: Column<EntityID<Int>> = reference("videoID", Videos)
-    val accountID: Column<EntityID<Int>> = reference("accountID", Accounts)
+    val videoID: Column<EntityID<Int>> = reference("videoID", Videos, onDelete = ReferenceOption.CASCADE)
+    val accountID: Column<EntityID<Int>> = reference("accountID", Accounts, onDelete = ReferenceOption.CASCADE)
     val rating: Column<Int> = integer("rating")
     init {
         uniqueIndex("UI_Ratings_vid_acc", videoID, accountID)

--- a/src/main/kotlin/gay/extremist/models/TagLabelsVideo.kt
+++ b/src/main/kotlin/gay/extremist/models/TagLabelsVideo.kt
@@ -2,12 +2,13 @@ package gay.extremist.models
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
 
 object TagLabelsVideo: Table() {
-    private val tag: Column<EntityID<Int>> = reference("tagID", Tags)
-    private val video: Column<EntityID<Int>> = reference("videoID", Videos)
+    private val tag: Column<EntityID<Int>> = reference("tagID", Tags, onDelete = ReferenceOption.CASCADE)
+    private val video: Column<EntityID<Int>> = reference("videoID", Videos, onDelete = ReferenceOption.CASCADE)
     override val primaryKey = PrimaryKey(
-        tag, video, name="PK_TagLabelsVideo_tag_vid"
+        tag, video
     )
 }

--- a/src/main/kotlin/gay/extremist/models/Video.kt
+++ b/src/main/kotlin/gay/extremist/models/Video.kt
@@ -6,11 +6,12 @@ import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.javatime.CurrentDateTime
 import org.jetbrains.exposed.sql.javatime.datetime
 
 object Videos: IntIdTable() {
-    val creatorID: Column<EntityID<Int>>  = reference("creatorID", Accounts)
+    val creatorID: Column<EntityID<Int>>  = reference("creatorID", Accounts, onDelete = ReferenceOption.CASCADE)
     val title: Column<String> = varchar("title", 255)
     val videoPath: Column<String> = varchar("videoPath", 255)
     val description: Column<String> = text("description")


### PR DESCRIPTION
Added the onDelete option to CASCADE for references in the Comment, PlaylistContainsVideo, Video, TagLabelsVideo, Ratings, Playlist, AccountFollowsAccount, and AccountFollowsTag classes to ensure data consistency when deleting related entities.